### PR TITLE
fix crash on malformed address header

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -9,7 +9,7 @@ module Mail2www
   module Helpers
     def get_addresses(mail, field_name)
       field = mail[field_name]
-      return [] unless field
+      return [] unless field&.element
 
       field.element.addresses.map do |mailbox|
         {

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -42,6 +42,12 @@ describe Mail2www::Helpers do
       )
       expect(get_addresses(message, :cc)).to eq([])
     end
+
+    it 'returns an empty array for a malformed address header' do
+      message = Mail.read_from_string("From: invalid address <\n\nBody")
+
+      expect(get_addresses(message, :from)).to eq([])
+    end
   end
 
   describe 'get_date' do


### PR DESCRIPTION
Mail can preserve an invalid address header as a field while leaving its parsed element nil. Treat that state like an absent address list.
